### PR TITLE
fix(chatgpt): stabilize initial timeline jumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/
 .claude/
+internal-docs/

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -106,22 +106,6 @@
     return scrollTop + focusOffset + epsilon;
   }
 
-  function normalizeMarkerPositions(input = {}) {
-    const positions = Array.isArray(input.positions) ? input.positions : [];
-    const previous = Array.isArray(input.previous) ? input.previous : [];
-    if (!positions.length) return [];
-    if (positions.some(position => !Number.isFinite(Number(position)))) {
-      return previous.length === positions.length ? previous.slice() : positions.map(() => 0);
-    }
-    const first = Number(positions[0]);
-    const last = Number(positions[positions.length - 1]);
-    const span = Math.max(1, last - first);
-    return positions.map(position => {
-      const normalized = (Number(position) - first) / span;
-      return Math.max(0, Math.min(1, normalized));
-    });
-  }
-
   function selectActiveIndex(input = {}) {
     const positions = Array.isArray(input.positions) ? input.positions : [];
     const referenceY = Number(input.referenceY);
@@ -139,7 +123,6 @@
   return {
     evaluateInitialJumpReadiness,
     evaluateScrollCorrection,
-    normalizeMarkerPositions,
     pickBestScrollableCandidate,
     resolveActiveReferenceY,
     resolveScrollAnchoring,

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -1,0 +1,133 @@
+(function (root, factory) {
+  const api = factory();
+  root.ChatGPTInitialJumpUtils = api;
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function evaluateInitialJumpReadiness(input = {}) {
+    const stableFrames = Math.max(0, Number(input.stableFrames) || 0);
+    const previousScrollTop = Number(input.previousScrollTop);
+    const currentScrollTop = Number(input.currentScrollTop);
+    const previousScrollHeight = Number(input.previousScrollHeight);
+    const currentScrollHeight = Number(input.currentScrollHeight);
+    const previousAnchorTop = Number(input.previousAnchorTop);
+    const currentAnchorTop = Number(input.currentAnchorTop);
+    const positionEpsilon = Math.max(0, Number(input.positionEpsilon) || 2);
+    const sizeEpsilon = Math.max(0, Number(input.sizeEpsilon) || 2);
+    const requiredStableFrames = Math.max(1, Number(input.requiredStableFrames) || 4);
+    const elapsedMs = Math.max(0, Number(input.elapsedMs) || 0);
+    const minReadyMs = Math.max(0, Number(input.minReadyMs) || 0);
+
+    if (
+      !Number.isFinite(previousScrollTop) ||
+      !Number.isFinite(currentScrollTop) ||
+      !Number.isFinite(previousScrollHeight) ||
+      !Number.isFinite(currentScrollHeight) ||
+      !Number.isFinite(previousAnchorTop) ||
+      !Number.isFinite(currentAnchorTop)
+    ) {
+      return {
+        frameStable: false,
+        stableFrames: 0,
+        ready: false
+      };
+    }
+
+    const maxPositionDelta = Math.max(
+      Math.abs(currentScrollTop - previousScrollTop),
+      Math.abs(currentAnchorTop - previousAnchorTop)
+    );
+    const sizeDelta = Math.abs(currentScrollHeight - previousScrollHeight);
+    const frameStable = maxPositionDelta <= positionEpsilon && sizeDelta <= sizeEpsilon;
+    const nextStableFrames = frameStable ? stableFrames + 1 : 0;
+
+    return {
+      frameStable,
+      stableFrames: nextStableFrames,
+      ready: nextStableFrames >= requiredStableFrames && elapsedMs >= minReadyMs
+    };
+  }
+
+  function evaluateScrollCorrection(input = {}) {
+    const delta = Math.abs(Number(input.delta) || 0);
+    const stableFrames = Math.max(0, Number(input.stableFrames) || 0);
+    const now = Number(input.now) || 0;
+    const deadline = Number(input.deadline) || 0;
+    const epsilon = Math.max(0, Number(input.epsilon) || 2);
+    const requiredStableFrames = Math.max(1, Number(input.requiredStableFrames) || 6);
+    return {
+      needsWrite: delta > epsilon,
+      shouldContinue: now < deadline && (delta > epsilon || stableFrames < requiredStableFrames)
+    };
+  }
+
+  function pickBestScrollableCandidate(candidates = []) {
+    let bestNonDocument = null;
+    let bestDocument = null;
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      const overflow = Math.max(0, Number(candidate.overflow) || 0);
+      if (overflow <= 0) continue;
+      const depth = Math.max(0, Number(candidate.depth) || 0);
+      const isDocument = !!candidate.isDocument;
+      const normalized = { ...candidate, overflow, isDocument, depth };
+      if (isDocument) {
+        if (!bestDocument || overflow > bestDocument.overflow) bestDocument = normalized;
+        continue;
+      }
+      if (!bestNonDocument || depth < bestNonDocument.depth || (depth === bestNonDocument.depth && overflow > bestNonDocument.overflow)) {
+        bestNonDocument = normalized;
+      }
+    }
+    return bestNonDocument || bestDocument;
+  }
+
+  function resolveScrollAnchoring(input = {}) {
+    return input.active ? 'none' : String(input.fallback || '');
+  }
+
+  function resolveScrollFocusOffset(input = {}) {
+    const containerScrollPaddingTop = Math.max(0, Number(input.containerScrollPaddingTop) || 0);
+    const fallbackOffset = Math.max(0, Number(input.fallbackOffset) || 0);
+    const gapOffset = Math.max(0, Number(input.gapOffset) || 0);
+    return (containerScrollPaddingTop > 0 ? containerScrollPaddingTop : fallbackOffset) + gapOffset;
+  }
+
+  function resolveScrollTarget(input = {}) {
+    const rawTop = Number(input.rawTop);
+    const focusOffset = Math.max(0, Number(input.focusOffset) || 0);
+    if (!Number.isFinite(rawTop)) return NaN;
+    return rawTop - focusOffset;
+  }
+
+  function resolveActiveReferenceY(input = {}) {
+    const scrollTop = Number(input.scrollTop) || 0;
+    const focusOffset = Math.max(0, Number(input.focusOffset) || 0);
+    const epsilon = Math.max(0, Number(input.epsilon) || 2);
+    return scrollTop + focusOffset + epsilon;
+  }
+
+  function selectActiveIndex(input = {}) {
+    const positions = Array.isArray(input.positions) ? input.positions : [];
+    const referenceY = Number(input.referenceY);
+    if (!positions.length || !Number.isFinite(referenceY)) return 0;
+    let active = 0;
+    for (let i = 0; i < positions.length; i++) {
+      const position = Number(positions[i]);
+      if (!Number.isFinite(position)) continue;
+      if (position <= referenceY) active = i;
+      else break;
+    }
+    return Math.max(0, Math.min(positions.length - 1, active));
+  }
+
+  return {
+    evaluateInitialJumpReadiness,
+    evaluateScrollCorrection,
+    pickBestScrollableCandidate,
+    resolveActiveReferenceY,
+    resolveScrollAnchoring,
+    resolveScrollFocusOffset,
+    resolveScrollTarget,
+    selectActiveIndex
+  };
+});

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -106,6 +106,127 @@
     return scrollTop + focusOffset + epsilon;
   }
 
+  function shouldRunTimelineJump(input = {}) {
+    const targetId = String(input.targetId || '').trim();
+    const activeTurnId = String(input.activeTurnId || '').trim();
+    if (!targetId) return false;
+    if (activeTurnId && targetId === activeTurnId) return false;
+    return true;
+  }
+
+  function normalizeMarkerRatios(input = {}) {
+    const positions = Array.isArray(input.positions) ? input.positions : [];
+    const previous = Array.isArray(input.previous) ? input.previous : [];
+    if (!positions.length) return [];
+    const numericPositions = positions.map(position => Number(position));
+    const previousRatios = previous.map(ratio => Number(ratio));
+    const hasPrevious = previousRatios.length === positions.length && previousRatios.every(ratio => Number.isFinite(ratio));
+    const fallback = () => hasPrevious ? previous.slice() : positions.map(() => 0);
+    if (numericPositions.some(position => !Number.isFinite(position))) {
+      return fallback();
+    }
+    for (let i = 1; i < numericPositions.length; i++) {
+      if (numericPositions[i] <= numericPositions[i - 1]) {
+        return fallback();
+      }
+    }
+    if (numericPositions.length > 1 && (numericPositions[numericPositions.length - 1] - numericPositions[0]) < 1) {
+      return fallback();
+    }
+    if (numericPositions.length === 1) {
+      return previous.length === positions.length ? previous.slice() : positions.map(() => 0);
+    }
+    const first = numericPositions[0];
+    const last = numericPositions[numericPositions.length - 1];
+    const span = Math.max(1, last - first);
+    const normalized = numericPositions.map(position => {
+      const normalized = (position - first) / span;
+      return Math.max(0, Math.min(1, normalized));
+    });
+    if (input.preservePreviousOnSkew && hasPrevious && normalized.length >= 4) {
+      const gaps = ratios => {
+        const out = [];
+        for (let i = 1; i < ratios.length; i++) out.push(Math.max(0, Number(ratios[i]) - Number(ratios[i - 1])));
+        return out;
+      };
+      const candidateGaps = gaps(normalized);
+      const previousGaps = gaps(previousRatios);
+      const candidateMax = Math.max(...candidateGaps);
+      const candidateMin = Math.min(...candidateGaps.filter(gap => gap > 0));
+      const previousMax = Math.max(...previousGaps);
+      const previousMin = Math.min(...previousGaps.filter(gap => gap > 0));
+      const candidateSpread = candidateMin > 0 ? candidateMax / candidateMin : Infinity;
+      const previousSpread = previousMin > 0 ? previousMax / previousMin : Infinity;
+      if (Number.isFinite(previousSpread) && candidateSpread > Math.max(6, previousSpread * 4)) {
+        return previous.slice();
+      }
+    }
+    return normalized;
+  }
+
+  function mapLiveReferenceToVisualRatio(input = {}) {
+    const livePositions = Array.isArray(input.livePositions) ? input.livePositions : [];
+    const visualRatios = Array.isArray(input.visualRatios) ? input.visualRatios : [];
+    const referenceY = Number(input.referenceY);
+    if (!livePositions.length || livePositions.length !== visualRatios.length || !Number.isFinite(referenceY)) return 0;
+    const firstLive = Number(livePositions[0]);
+    const firstRatio = Number(visualRatios[0]);
+    if (!Number.isFinite(firstLive) || !Number.isFinite(firstRatio)) return 0;
+    if (referenceY <= firstLive) return Math.max(0, Math.min(1, firstRatio));
+
+    for (let i = 1; i < livePositions.length; i++) {
+      const prevLive = Number(livePositions[i - 1]);
+      const nextLive = Number(livePositions[i]);
+      const prevRatio = Number(visualRatios[i - 1]);
+      const nextRatio = Number(visualRatios[i]);
+      if (
+        !Number.isFinite(prevLive) ||
+        !Number.isFinite(nextLive) ||
+        !Number.isFinite(prevRatio) ||
+        !Number.isFinite(nextRatio)
+      ) {
+        continue;
+      }
+      if (referenceY <= nextLive) {
+        const span = Math.max(1, nextLive - prevLive);
+        const progress = Math.max(0, Math.min(1, (referenceY - prevLive) / span));
+        return Math.max(0, Math.min(1, prevRatio + (nextRatio - prevRatio) * progress));
+      }
+    }
+
+    const lastRatio = Number(visualRatios[visualRatios.length - 1]);
+    return Math.max(0, Math.min(1, Number.isFinite(lastRatio) ? lastRatio : 1));
+  }
+
+  function calculateTimelineContentHeight(input = {}) {
+    const viewportHeight = Math.max(0, Number(input.viewportHeight) || 0);
+    const padding = Math.max(0, Number(input.padding) || 0);
+    const minGap = Math.max(0, Number(input.minGap) || 0);
+    const markerRatios = Array.isArray(input.markerRatios) ? input.markerRatios : [];
+    const markerCount = markerRatios.length;
+    const countHeight = markerCount > 0 ? (2 * padding + Math.max(0, markerCount - 1) * minGap) : viewportHeight;
+    let desired = Math.max(viewportHeight, countHeight);
+
+    let minRatioGap = Infinity;
+    let previous = null;
+    for (const value of markerRatios) {
+      const ratio = Number(value);
+      if (!Number.isFinite(ratio)) continue;
+      const clamped = Math.max(0, Math.min(1, ratio));
+      if (previous !== null) {
+        const gap = clamped - previous;
+        if (gap > 0) minRatioGap = Math.min(minRatioGap, gap);
+      }
+      previous = clamped;
+    }
+
+    if (Number.isFinite(minRatioGap) && minRatioGap > 0 && minGap > 0) {
+      desired = Math.max(desired, 2 * padding + minGap / minRatioGap);
+    }
+
+    return Math.ceil(desired);
+  }
+
   function selectActiveIndex(input = {}) {
     const positions = Array.isArray(input.positions) ? input.positions : [];
     const referenceY = Number(input.referenceY);
@@ -123,6 +244,10 @@
   return {
     evaluateInitialJumpReadiness,
     evaluateScrollCorrection,
+    calculateTimelineContentHeight,
+    mapLiveReferenceToVisualRatio,
+    normalizeMarkerRatios,
+    shouldRunTimelineJump,
     pickBestScrollableCandidate,
     resolveActiveReferenceY,
     resolveScrollAnchoring,

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -134,7 +134,7 @@
       return fallback();
     }
     if (numericPositions.length === 1) {
-      return previous.length === positions.length ? previous.slice() : positions.map(() => 0);
+      return hasPrevious ? previousRatios.map(ratio => Math.max(0, Math.min(1, ratio))) : [0];
     }
     const first = numericPositions[0];
     const last = numericPositions[numericPositions.length - 1];

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -106,6 +106,22 @@
     return scrollTop + focusOffset + epsilon;
   }
 
+  function normalizeMarkerPositions(input = {}) {
+    const positions = Array.isArray(input.positions) ? input.positions : [];
+    const previous = Array.isArray(input.previous) ? input.previous : [];
+    if (!positions.length) return [];
+    if (positions.some(position => !Number.isFinite(Number(position)))) {
+      return previous.length === positions.length ? previous.slice() : positions.map(() => 0);
+    }
+    const first = Number(positions[0]);
+    const last = Number(positions[positions.length - 1]);
+    const span = Math.max(1, last - first);
+    return positions.map(position => {
+      const normalized = (Number(position) - first) / span;
+      return Math.max(0, Math.min(1, normalized));
+    });
+  }
+
   function selectActiveIndex(input = {}) {
     const positions = Array.isArray(input.positions) ? input.positions : [];
     const referenceY = Number(input.referenceY);
@@ -123,6 +139,7 @@
   return {
     evaluateInitialJumpReadiness,
     evaluateScrollCorrection,
+    normalizeMarkerPositions,
     pickBestScrollableCandidate,
     resolveActiveReferenceY,
     resolveScrollAnchoring,

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -1,3 +1,5 @@
+const InitialJumpUtils = globalThis.ChatGPTInitialJumpUtils;
+
 class TimelineManager {
     constructor() {
         this.scrollContainer = null;
@@ -21,6 +23,19 @@ class TimelineManager {
         this.onWindowResize = null;
         this.onTimelineWheel = null;
         this.scrollRafId = null;
+        this.smoothScrollRafId = null;
+        this.smoothScrollSession = 0;
+        this.scrollCorrectionRafId = null;
+        this.scrollCorrectionSession = 0;
+        this.initialJumpRafId = null;
+        this.initialJumpReady = false;
+        this.initialJumpStableFrames = 0;
+        this.initialJumpMetrics = null;
+        this.initialJumpStartedAt = 0;
+        this.initialJumpReadyDeadline = 0;
+        this.pendingInitialJump = null;
+        this.scrollAnchoringRestoreValue = null;
+        this.scrollAnchoringLockCount = 0;
         this.lastActiveChangeTime = 0;
         this.minActiveChangeInterval = 120; // ms
         this.pendingActiveId = null;
@@ -38,6 +53,7 @@ class TimelineManager {
         this.scale = 1;
         this.contentHeight = 0;
         this.yPositions = [];
+        this.markerScrollPositions = [];
         this.visibleRange = { start: 0, end: -1 };
         this.firstUserTurnOffset = 0;
         this.contentSpanPx = 1;
@@ -75,6 +91,7 @@ class TimelineManager {
         this.pressStartPos = null;
         this.pressTargetDot = null;
         this.suppressClickUntil = 0;
+        this.suppressActiveUntil = 0;
         // Cross-tab sync
         this.onStorage = null;
     }
@@ -123,8 +140,9 @@ class TimelineManager {
             }
         } catch {}
         // Initial rendering will be triggered by observers; avoid duplicate delayed re-render
+        this.startInitialJumpReadinessWatch();
     }
-    
+
     async findCriticalElements() {
         const firstTurn = await this.waitForElement('[data-turn-id]');
         if (!firstTurn) return false;
@@ -143,15 +161,7 @@ class TimelineManager {
         this.conversationContainer = root || firstTurn.parentElement;
         if (!this.conversationContainer) return false;
 
-        let parent = this.conversationContainer;
-        while (parent && parent !== document.body) {
-            const style = window.getComputedStyle(parent);
-            if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-                this.scrollContainer = parent;
-                break;
-            }
-            parent = parent.parentElement;
-        }
+        this.scrollContainer = this.getScrollableAncestor(this.conversationContainer);
         return this.scrollContainer !== null;
     }
     
@@ -261,24 +271,20 @@ class TimelineManager {
         // Clear old dots from track/content (now that we know content exists)
         (this.ui.trackContent || this.ui.timelineBar).querySelectorAll('.timeline-dot').forEach(n => n.remove());
 
-        let contentSpan;
-        const firstTurnOffset = userTurnElements[0].offsetTop;
-        if (userTurnElements.length < 2) {
-            contentSpan = 1;
-        } else {
-            const lastTurnOffset = userTurnElements[userTurnElements.length - 1].offsetTop;
-            contentSpan = lastTurnOffset - firstTurnOffset;
-        }
-        if (contentSpan <= 0) contentSpan = 1;
+        const measuredPositions = Array.from(userTurnElements).map(el => this.getElementScrollAnchorTop(el));
+        const firstTurnOffset = measuredPositions[0] || 0;
+        const lastTurnOffset = measuredPositions[measuredPositions.length - 1] || firstTurnOffset;
+        const contentSpan = Math.max(1, lastTurnOffset - firstTurnOffset);
 
         // Cache for scroll mapping
         this.firstUserTurnOffset = firstTurnOffset;
         this.contentSpanPx = contentSpan;
+        this.markerScrollPositions = measuredPositions;
 
         // Build markers with normalized position along conversation
         this.markerMap.clear();
-        this.markers = Array.from(userTurnElements).map(el => {
-            const offsetFromStart = el.offsetTop - firstTurnOffset;
+        this.markers = Array.from(userTurnElements).map((el, index) => {
+            const offsetFromStart = measuredPositions[index] - firstTurnOffset;
             let n = offsetFromStart / contentSpan;
             n = Math.max(0, Math.min(1, n));
             const m = {
@@ -393,18 +399,7 @@ class TimelineManager {
 
         this.conversationContainer = newConv;
 
-        // Find (or re-find) scroll container
-        let parent = newConv;
-        let newScroll = null;
-        while (parent && parent !== document.body) {
-            const style = window.getComputedStyle(parent);
-            if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-                newScroll = parent; break;
-            }
-            parent = parent.parentElement;
-        }
-        if (!newScroll) newScroll = document.scrollingElement || document.documentElement || document.body;
-        this.scrollContainer = newScroll;
+        this.scrollContainer = this.getScrollableAncestor(newConv);
         // Reattach scroll listener
         this.onScroll = () => this.scheduleScrollSync();
         this.scrollContainer.addEventListener('scroll', this.onScroll, { passive: true });
@@ -448,7 +443,7 @@ class TimelineManager {
                 const targetElement = this.conversationContainer.querySelector(`[data-turn-id="${targetId}"]`);
                 if (targetElement) {
                     // Only scroll; let scroll-based computation set active to avoid double-flash
-                    this.smoothScrollTo(targetElement);
+                    this.queueOrRunTimelineJump(targetId);
                 }
             }
         };
@@ -660,28 +655,445 @@ class TimelineManager {
         try { window.addEventListener('storage', this.onStorage); } catch {}
     }
     
-    smoothScrollTo(targetElement, duration = 600) {
+    cancelSmoothScroll() {
+        this.smoothScrollSession++;
+        if (this.smoothScrollRafId !== null) {
+            try { cancelAnimationFrame(this.smoothScrollRafId); } catch {}
+            this.smoothScrollRafId = null;
+        }
+        this.isScrolling = false;
+        this.unlockScrollAnchoring();
+    }
+
+    cancelScrollCorrection() {
+        this.scrollCorrectionSession = (Number(this.scrollCorrectionSession) || 0) + 1;
+        if (this.scrollCorrectionRafId !== null) {
+            try { cancelAnimationFrame(this.scrollCorrectionRafId); } catch {}
+            this.scrollCorrectionRafId = null;
+        }
+        this.unlockScrollAnchoring();
+    }
+
+    cancelInitialJumpReadinessWatch() {
+        if (this.initialJumpRafId !== null) {
+            try { cancelAnimationFrame(this.initialJumpRafId); } catch {}
+            this.initialJumpRafId = null;
+        }
+    }
+
+    lockScrollAnchoring() {
+        if (!this.scrollContainer) return;
+        this.scrollAnchoringLockCount = Math.max(0, Number(this.scrollAnchoringLockCount) || 0) + 1;
+        if (this.scrollAnchoringLockCount > 1) return;
+        try {
+            this.scrollAnchoringRestoreValue = this.scrollContainer.style.overflowAnchor || '';
+            this.scrollContainer.style.overflowAnchor = InitialJumpUtils.resolveScrollAnchoring({
+                active: true,
+                fallback: this.scrollAnchoringRestoreValue
+            });
+        } catch {}
+    }
+
+    isElementScrollable(el) {
+        if (!el) return false;
+        try {
+            const style = window.getComputedStyle(el);
+            const overflowY = String(style.overflowY || '').toLowerCase();
+            const allowed = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
+            if (!allowed && el !== document.scrollingElement && el !== document.documentElement && el !== document.body) return false;
+            if ((el.scrollHeight - el.clientHeight) > 4) return true;
+            const previous = el.scrollTop;
+            el.scrollTop = previous + 1;
+            const changed = el.scrollTop !== previous;
+            el.scrollTop = previous;
+            return changed;
+        } catch {
+            return false;
+        }
+    }
+
+    getScrollableAncestor(startEl) {
+        const candidates = [];
+        let node = startEl;
+        let depth = 0;
+        while (node && node !== document.body) {
+            if (this.isElementScrollable(node)) {
+                candidates.push({
+                    element: node,
+                    overflow: Math.max(0, (node.scrollHeight || 0) - (node.clientHeight || 0)),
+                    isDocument: false,
+                    depth
+                });
+            }
+            node = node.parentElement;
+            depth++;
+        }
+        const documentScroll = document.scrollingElement || document.documentElement || document.body;
+        if (this.isElementScrollable(documentScroll)) {
+            candidates.push({
+                element: documentScroll,
+                overflow: Math.max(0, (documentScroll.scrollHeight || 0) - (documentScroll.clientHeight || 0)),
+                isDocument: true,
+                depth: Number.MAX_SAFE_INTEGER
+            });
+        }
+        const best = InitialJumpUtils.pickBestScrollableCandidate(candidates);
+        return best?.element || documentScroll;
+    }
+
+    unlockScrollAnchoring() {
+        if (!this.scrollContainer) {
+            this.scrollAnchoringLockCount = 0;
+            this.scrollAnchoringRestoreValue = null;
+            return;
+        }
+        this.scrollAnchoringLockCount = Math.max(0, Number(this.scrollAnchoringLockCount) || 0);
+        if (this.scrollAnchoringLockCount === 0) return;
+        this.scrollAnchoringLockCount--;
+        if (this.scrollAnchoringLockCount > 0) return;
+        try {
+            this.scrollContainer.style.overflowAnchor = InitialJumpUtils.resolveScrollAnchoring({
+                active: false,
+                fallback: this.scrollAnchoringRestoreValue
+            });
+            if (!this.scrollAnchoringRestoreValue) {
+                try { this.scrollContainer.style.removeProperty('overflow-anchor'); } catch {}
+            }
+        } catch {}
+        this.scrollAnchoringRestoreValue = null;
+    }
+
+    resolvePendingJumpTarget(pending = this.pendingInitialJump) {
+        const targetId = String(pending?.targetId || '').trim();
+        if (!targetId || !this.conversationContainer) return null;
+        const turnElement = this.conversationContainer.querySelector(`[data-turn-id="${CSS.escape(targetId)}"]`);
+        const targetElement = this.resolveTurnScrollAnchor(turnElement);
+        if (!targetElement) return null;
+        return { targetId, turnElement, targetElement };
+    }
+
+    resolveTurnScrollAnchor(turnElement) {
+        if (!turnElement) return null;
+        const textSelectors = [
+            '.whitespace-pre-wrap',
+            '[dir="auto"]',
+            '.markdown',
+            'p',
+            'pre'
+        ];
+        let textAnchor = null;
+        for (const selector of textSelectors) {
+            try {
+                const candidates = Array.from(turnElement.querySelectorAll(selector));
+                for (const candidate of candidates) {
+                    const text = String(candidate.innerText || candidate.textContent || '').replace(/\s+/g, ' ').trim();
+                    if (!text) continue;
+                    textAnchor = candidate;
+                    break;
+                }
+            } catch {}
+            if (textAnchor) break;
+        }
+        if (!textAnchor) return turnElement;
+
+        let bubbleAnchor = textAnchor;
+        let node = textAnchor;
+        while (node && node !== turnElement) {
+            try {
+                const style = getComputedStyle(node);
+                const backgroundColor = String(style.backgroundColor || '').trim().toLowerCase();
+                const hasBackground = backgroundColor && backgroundColor !== 'rgba(0, 0, 0, 0)' && backgroundColor !== 'transparent';
+                const radius = parseFloat(style.borderTopLeftRadius || '0') || 0;
+                const hasBorder = (parseFloat(style.borderTopWidth || '0') || 0) > 0;
+                const hasPadding = ((parseFloat(style.paddingTop || '0') || 0) + (parseFloat(style.paddingBottom || '0') || 0)) > 0;
+                if ((hasBackground || hasBorder) && (radius > 0 || hasPadding)) {
+                    bubbleAnchor = node;
+                }
+            } catch {}
+            node = node.parentElement;
+        }
+        return bubbleAnchor || textAnchor || turnElement;
+    }
+
+    getTargetScrollTop(targetElement) {
+        if (!this.scrollContainer || !targetElement) return NaN;
         const containerRect = this.scrollContainer.getBoundingClientRect();
         const targetRect = targetElement.getBoundingClientRect();
-        const targetPosition = targetRect.top - containerRect.top + this.scrollContainer.scrollTop;
+        const rawTop = targetRect.top - containerRect.top + this.scrollContainer.scrollTop;
+        return InitialJumpUtils.resolveScrollTarget({
+            rawTop,
+            focusOffset: this.getScrollFocusOffset()
+        });
+    }
+
+    readComputedPixelValue(...values) {
+        for (const value of values) {
+            const text = String(value || '').trim();
+            if (!text) continue;
+            const n = parseFloat(text);
+            if (Number.isFinite(n)) return n;
+        }
+        return 0;
+    }
+
+    getScrollFocusOffset() {
+        if (!this.scrollContainer) return 2;
+        try {
+            const style = getComputedStyle(this.scrollContainer);
+            const containerScrollPaddingTop = this.readComputedPixelValue(
+                style.getPropertyValue?.('scroll-padding-top'),
+                style.getPropertyValue?.('--sticky-padding-top')
+            );
+            return InitialJumpUtils.resolveScrollFocusOffset({
+                containerScrollPaddingTop,
+                fallbackOffset: 2,
+                gapOffset: 12
+            });
+        } catch {
+            return 14;
+        }
+    }
+
+    getActiveReferenceY(scrollTop = this.scrollContainer?.scrollTop || 0) {
+        return InitialJumpUtils.resolveActiveReferenceY({
+            scrollTop,
+            focusOffset: this.getScrollFocusOffset(),
+            epsilon: 2
+        });
+    }
+
+    getElementScrollAnchorTop(targetElement) {
+        const anchorElement = this.resolveTurnScrollAnchor(targetElement);
+        const top = this.getTargetScrollTop(anchorElement);
+        if (Number.isFinite(top)) return top;
+        try { return Number(targetElement?.offsetTop) || 0; } catch { return 0; }
+    }
+
+    refreshMarkerScrollPositions() {
+        if (!this.markers.length) {
+            this.markerScrollPositions = [];
+            return this.markerScrollPositions;
+        }
+        const positions = this.markers.map(marker => this.getElementScrollAnchorTop(marker.element));
+        this.markerScrollPositions = positions;
+        const first = positions[0] || 0;
+        const last = positions[positions.length - 1] || first;
+        this.firstUserTurnOffset = first;
+        this.contentSpanPx = Math.max(1, last - first);
+        return positions;
+    }
+
+    captureInitialJumpMetrics() {
+        if (!this.scrollContainer) return null;
+        const pendingTarget = this.resolvePendingJumpTarget();
+        let anchorTop = pendingTarget?.targetElement ? this.getTargetScrollTop(pendingTarget.targetElement) : NaN;
+        if (!Number.isFinite(anchorTop)) {
+            const probeTarget = this.markers[0]?.element || this.conversationContainer?.querySelector?.('[data-turn="user"][data-turn-id]');
+            anchorTop = this.getTargetScrollTop(probeTarget);
+        }
+        return {
+            scrollTop: Number(this.scrollContainer.scrollTop) || 0,
+            scrollHeight: Number(this.scrollContainer.scrollHeight) || 0,
+            anchorTop: Number.isFinite(anchorTop) ? anchorTop : 0
+        };
+    }
+
+    markInitialJumpReady(reason = 'stable') {
+        if (this.initialJumpReady) return;
+        this.initialJumpReady = true;
+        this.initialJumpStableFrames = 0;
+        this.initialJumpMetrics = null;
+        this.initialJumpStartedAt = 0;
+        this.initialJumpReadyDeadline = 0;
+        this.cancelInitialJumpReadinessWatch();
+        if (!this.pendingInitialJump) return;
+        const pending = this.resolvePendingJumpTarget();
+        this.pendingInitialJump = null;
+        if (pending?.targetElement) {
+            this.activeTurnId = pending.targetId;
+            this.pendingActiveId = null;
+            this.updateActiveDotUI();
+            this.smoothScrollTo(pending.targetElement);
+        }
+    }
+
+    startInitialJumpReadinessWatch() {
+        if (this.initialJumpReady || !this.scrollContainer) return;
+        if (!this.initialJumpReadyDeadline) {
+            const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            this.initialJumpStartedAt = now;
+            this.initialJumpReadyDeadline = now + 1600;
+        }
+        if (this.initialJumpRafId !== null) return;
+
+        const tick = () => {
+            this.initialJumpRafId = null;
+            if (this.initialJumpReady || !this.scrollContainer) return;
+            const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const currentMetrics = this.captureInitialJumpMetrics();
+            const previousMetrics = this.initialJumpMetrics;
+            this.initialJumpMetrics = currentMetrics;
+            const readiness = InitialJumpUtils.evaluateInitialJumpReadiness({
+                stableFrames: this.initialJumpStableFrames,
+                previousScrollTop: previousMetrics?.scrollTop,
+                currentScrollTop: currentMetrics?.scrollTop,
+                previousScrollHeight: previousMetrics?.scrollHeight,
+                currentScrollHeight: currentMetrics?.scrollHeight,
+                previousAnchorTop: previousMetrics?.anchorTop,
+                currentAnchorTop: currentMetrics?.anchorTop,
+                elapsedMs: now - (this.initialJumpStartedAt || now),
+                minReadyMs: 250
+            });
+            this.initialJumpStableFrames = readiness.stableFrames;
+            if (readiness.ready) {
+                this.markInitialJumpReady('stable-frames');
+                return;
+            }
+            if (now >= this.initialJumpReadyDeadline) {
+                this.markInitialJumpReady('deadline');
+                return;
+            }
+            this.initialJumpRafId = requestAnimationFrame(tick);
+        };
+
+        this.initialJumpRafId = requestAnimationFrame(tick);
+    }
+
+    queueOrRunTimelineJump(targetId) {
+        const resolved = this.resolvePendingJumpTarget({ targetId });
+        if (!resolved?.targetElement) return;
+        this.activeTurnId = resolved.targetId;
+        this.pendingActiveId = null;
+        this.updateActiveDotUI();
+        if (!this.initialJumpReady) {
+            this.pendingInitialJump = { targetId };
+            this.startInitialJumpReadinessWatch();
+            return;
+        }
+        this.pendingInitialJump = null;
+        this.smoothScrollTo(resolved.targetElement);
+    }
+
+    smoothScrollTo(targetElement, duration = 600) {
+        this.cancelSmoothScroll();
+        this.cancelScrollCorrection();
+        this.lockScrollAnchoring();
+        const session = this.smoothScrollSession;
+        const container = this.scrollContainer;
+        const targetPosition = this.getTargetScrollTop(targetElement);
+        if (!Number.isFinite(targetPosition)) {
+            this.unlockScrollAnchoring();
+            return;
+        }
         const startPosition = this.scrollContainer.scrollTop;
-        const distance = targetPosition - startPosition;
+        const nowBase = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        this.suppressActiveUntil = nowBase + duration + 1800;
         let startTime = null;
 
         const animation = (currentTime) => {
+            if (session !== this.smoothScrollSession || !this.scrollContainer || this.scrollContainer !== container) return;
             this.isScrolling = true;
             if (startTime === null) startTime = currentTime;
             const timeElapsed = currentTime - startTime;
-            const run = this.easeInOutQuad(timeElapsed, startPosition, distance, duration);
+            const liveTargetPosition = this.getTargetScrollTop(targetElement);
+            const effectiveTarget = Number.isFinite(liveTargetPosition) ? liveTargetPosition : targetPosition;
+            const liveDistance = effectiveTarget - startPosition;
+            const run = this.easeInOutQuad(timeElapsed, startPosition, liveDistance, duration);
             this.scrollContainer.scrollTop = run;
             if (timeElapsed < duration) {
-                requestAnimationFrame(animation);
+                this.smoothScrollRafId = requestAnimationFrame(animation);
             } else {
-                this.scrollContainer.scrollTop = targetPosition;
+                const finalTargetPosition = this.getTargetScrollTop(targetElement);
+                this.scrollContainer.scrollTop = Number.isFinite(finalTargetPosition) ? finalTargetPosition : effectiveTarget;
+                this.correctScrollPositionNow(targetElement, 6);
                 this.isScrolling = false;
+                this.smoothScrollRafId = null;
+                this.beginScrollCorrection(targetElement, {
+                    reason: 'timeline-click'
+                });
             }
         };
-        requestAnimationFrame(animation);
+        this.smoothScrollRafId = requestAnimationFrame(animation);
+    }
+
+    correctScrollPositionNow(targetElement, maxWrites = 6) {
+        if (!this.scrollContainer || !targetElement) return false;
+        let wrote = false;
+        for (let i = 0; i < maxWrites; i++) {
+            const targetTop = this.getTargetScrollTop(targetElement);
+            if (!Number.isFinite(targetTop)) break;
+            const delta = targetTop - this.scrollContainer.scrollTop;
+            if (Math.abs(delta) <= 1) break;
+            this.scrollContainer.scrollTop = targetTop;
+            wrote = true;
+            try { targetElement.getBoundingClientRect(); } catch {}
+        }
+        return wrote;
+    }
+
+    beginScrollCorrection(targetElement, options = {}) {
+        if (!this.scrollContainer || !targetElement) return;
+        this.cancelScrollCorrection();
+        this.lockScrollAnchoring();
+        const session = this.scrollCorrectionSession;
+        const wantedTurnId = String(options.wantedTurnId || targetElement?.closest?.('[data-turn-id]')?.dataset?.turnId || '').trim() || null;
+        const nowBase = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const deadline = nowBase + Math.max(400, Number(options.durationMs) || 1800);
+        let stableFrames = 0;
+        this.suppressActiveUntil = deadline;
+
+        const tick = () => {
+            if (session !== this.scrollCorrectionSession || !this.scrollContainer) return;
+            if (!targetElement?.isConnected) {
+                this.scrollCorrectionRafId = null;
+                this.suppressActiveUntil = 0;
+                this.unlockScrollAnchoring();
+                return;
+            }
+            const targetTop = this.getTargetScrollTop(targetElement);
+            if (!Number.isFinite(targetTop)) {
+                this.scrollCorrectionRafId = null;
+                this.suppressActiveUntil = 0;
+                this.unlockScrollAnchoring();
+                return;
+            }
+            const currentTop = this.scrollContainer.scrollTop;
+            const delta = targetTop - currentTop;
+            const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const decision = InitialJumpUtils.evaluateScrollCorrection({
+                delta,
+                stableFrames,
+                now,
+                deadline
+            });
+            if (decision.needsWrite) {
+                this.scrollContainer.scrollTop = targetTop;
+                stableFrames = 0;
+            } else {
+                stableFrames++;
+            }
+
+            if (wantedTurnId) {
+                this.activeTurnId = wantedTurnId;
+                this.pendingActiveId = null;
+                this.updateActiveDotUI();
+            }
+            this.refreshMarkerScrollPositions();
+            this.syncTimelineTrackToMain();
+            this.updateVirtualRangeAndRender();
+
+            if (decision.shouldContinue) {
+                this.scrollCorrectionRafId = requestAnimationFrame(tick);
+                return;
+            }
+
+            this.scrollCorrectionRafId = null;
+            this.suppressActiveUntil = 0;
+            this.unlockScrollAnchoring();
+            this.scheduleScrollSync();
+        };
+
+        this.scrollCorrectionRafId = requestAnimationFrame(tick);
     }
     
     easeInOutQuad(t, b, c, d) {
@@ -986,7 +1398,8 @@ class TimelineManager {
         if (this.sliderDragging) return; // do not override when user drags slider
         if (!this.ui.track || !this.scrollContainer || !this.contentHeight) return;
         const scrollTop = this.scrollContainer.scrollTop;
-        const ref = scrollTop + this.scrollContainer.clientHeight * 0.45;
+        const ref = this.getActiveReferenceY(scrollTop);
+        this.refreshMarkerScrollPositions();
         const span = Math.max(1, this.contentSpanPx || 1);
         const r = Math.max(0, Math.min(1, (ref - (this.firstUserTurnOffset || 0)) / span));
         const maxScroll = Math.max(0, this.contentHeight - (this.ui.track.clientHeight || 0));
@@ -1257,22 +1670,18 @@ class TimelineManager {
 
     computeActiveByScroll() {
         if (!this.scrollContainer || this.markers.length === 0) return;
-        const containerRect = this.scrollContainer.getBoundingClientRect();
+        const nowCheck = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        if (nowCheck < (this.suppressActiveUntil || 0)) return;
         const scrollTop = this.scrollContainer.scrollTop;
-        const ref = scrollTop + this.scrollContainer.clientHeight * 0.45;
-
-        let activeId = this.markers[0].id;
-        for (let i = 0; i < this.markers.length; i++) {
-            const m = this.markers[i];
-            const top = m.element.getBoundingClientRect().top - containerRect.top + scrollTop;
-            if (top <= ref) {
-                activeId = m.id;
-            } else {
-                break;
-            }
-        }
+        const ref = this.getActiveReferenceY(scrollTop);
+        const positions = this.refreshMarkerScrollPositions();
+        const activeIndex = InitialJumpUtils.selectActiveIndex({
+            positions,
+            referenceY: ref
+        });
+        const activeId = this.markers[activeIndex]?.id || this.markers[0].id;
         if (this.activeTurnId !== activeId) {
-            const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const now = nowCheck;
             const since = now - this.lastActiveChangeTime;
             if (since < this.minActiveChangeInterval) {
                 // Coalesce rapid changes during fast scrolling/layout shifts
@@ -1357,6 +1766,9 @@ class TimelineManager {
             try { cancelAnimationFrame(this.scrollRafId); } catch {}
             this.scrollRafId = null;
         }
+        this.cancelSmoothScroll();
+        this.cancelScrollCorrection();
+        this.cancelInitialJumpReadinessWatch();
         try { this.ui.timelineBar?.remove(); } catch {}
         try { this.ui.tooltip?.remove(); } catch {}
         try { this.measureEl?.remove(); } catch {}
@@ -1380,6 +1792,8 @@ class TimelineManager {
         this.activeTurnId = null;
         this.scrollContainer = null;
         this.conversationContainer = null;
+        this.initialJumpMetrics = null;
+        this.pendingInitialJump = null;
         this.onTimelineBarClick = null;
         this.onTimelineBarOver = null;
         this.onTimelineBarOut = null;

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -875,26 +875,11 @@ class TimelineManager {
             return this.markerScrollPositions;
         }
         const positions = this.markers.map(marker => this.getElementScrollAnchorTop(marker.element));
-        const previousNormalized = this.markers.map(marker => Number.isFinite(Number(marker.baseN)) ? Number(marker.baseN) : 0);
-        const normalized = InitialJumpUtils.normalizeMarkerPositions({
-            positions,
-            previous: previousNormalized
-        });
-        let visualPositionsChanged = false;
-        for (let i = 0; i < this.markers.length; i++) {
-            const nextN = Number(normalized[i]);
-            if (!Number.isFinite(nextN)) continue;
-            if (Math.abs(nextN - previousNormalized[i]) > 0.001) {
-                this.markers[i].baseN = nextN;
-                visualPositionsChanged = true;
-            }
-        }
         this.markerScrollPositions = positions;
         const first = positions[0] || 0;
         const last = positions[positions.length - 1] || first;
         this.firstUserTurnOffset = first;
         this.contentSpanPx = Math.max(1, last - first);
-        if (visualPositionsChanged) this.updateTimelineGeometry();
         return positions;
     }
 

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -875,11 +875,26 @@ class TimelineManager {
             return this.markerScrollPositions;
         }
         const positions = this.markers.map(marker => this.getElementScrollAnchorTop(marker.element));
+        const previousNormalized = this.markers.map(marker => Number.isFinite(Number(marker.baseN)) ? Number(marker.baseN) : 0);
+        const normalized = InitialJumpUtils.normalizeMarkerPositions({
+            positions,
+            previous: previousNormalized
+        });
+        let visualPositionsChanged = false;
+        for (let i = 0; i < this.markers.length; i++) {
+            const nextN = Number(normalized[i]);
+            if (!Number.isFinite(nextN)) continue;
+            if (Math.abs(nextN - previousNormalized[i]) > 0.001) {
+                this.markers[i].baseN = nextN;
+                visualPositionsChanged = true;
+            }
+        }
         this.markerScrollPositions = positions;
         const first = positions[0] || 0;
         const last = positions[positions.length - 1] || first;
         this.firstUserTurnOffset = first;
         this.contentSpanPx = Math.max(1, last - first);
+        if (visualPositionsChanged) this.updateTimelineGeometry();
         return positions;
     }
 

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -271,10 +271,18 @@ class TimelineManager {
         // Clear old dots from track/content (now that we know content exists)
         (this.ui.trackContent || this.ui.timelineBar).querySelectorAll('.timeline-dot').forEach(n => n.remove());
 
-        const measuredPositions = Array.from(userTurnElements).map(el => this.getElementScrollAnchorTop(el));
+        const turnElements = Array.from(userTurnElements);
+        const measuredPositions = turnElements.map(el => this.getElementScrollAnchorTop(el));
         const firstTurnOffset = measuredPositions[0] || 0;
         const lastTurnOffset = measuredPositions[measuredPositions.length - 1] || firstTurnOffset;
         const contentSpan = Math.max(1, lastTurnOffset - firstTurnOffset);
+        const previousRatiosById = new Map(this.markers.map(marker => [marker.id, marker.baseN ?? marker.n ?? 0]));
+        const previousRatios = turnElements.map(el => previousRatiosById.get(el.dataset.turnId));
+        const markerRatios = InitialJumpUtils.normalizeMarkerRatios({
+            positions: measuredPositions,
+            previous: previousRatios,
+            preservePreviousOnSkew: previousRatiosById.size > 0
+        });
 
         // Cache for scroll mapping
         this.firstUserTurnOffset = firstTurnOffset;
@@ -283,9 +291,8 @@ class TimelineManager {
 
         // Build markers with normalized position along conversation
         this.markerMap.clear();
-        this.markers = Array.from(userTurnElements).map((el, index) => {
-            const offsetFromStart = measuredPositions[index] - firstTurnOffset;
-            let n = offsetFromStart / contentSpan;
+        this.markers = turnElements.map((el, index) => {
+            let n = markerRatios[index];
             n = Math.max(0, Math.min(1, n));
             const m = {
                 id: el.dataset.turnId,
@@ -401,7 +408,9 @@ class TimelineManager {
 
         this.scrollContainer = this.getScrollableAncestor(newConv);
         // Reattach scroll listener
-        this.onScroll = () => this.scheduleScrollSync();
+        this.onScroll = () => {
+            this.scheduleScrollSync();
+        };
         this.scrollContainer.addEventListener('scroll', this.onScroll, { passive: true });
 
         // Recreate IntersectionObserver with new root
@@ -492,7 +501,9 @@ class TimelineManager {
             this.ui.timelineBar.addEventListener('pointerleave', this.onPointerLeave);
         } catch {}
         // Listen to container scroll to keep marker active state in sync
-        this.onScroll = () => this.scheduleScrollSync();
+        this.onScroll = () => {
+            this.scheduleScrollSync();
+        };
         this.scrollContainer.addEventListener('scroll', this.onScroll, { passive: true });
 
         // Tooltip interactions (delegated)
@@ -700,7 +711,8 @@ class TimelineManager {
             const style = window.getComputedStyle(el);
             const overflowY = String(style.overflowY || '').toLowerCase();
             const allowed = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
-            if (!allowed && el !== document.scrollingElement && el !== document.documentElement && el !== document.body) return false;
+            const isDocument = el === document.scrollingElement || el === document.documentElement || el === document.body;
+            if (!allowed && !isDocument) return false;
             if ((el.scrollHeight - el.clientHeight) > 4) return true;
             const previous = el.scrollTop;
             el.scrollTop = previous + 1;
@@ -962,6 +974,14 @@ class TimelineManager {
     queueOrRunTimelineJump(targetId) {
         const resolved = this.resolvePendingJumpTarget({ targetId });
         if (!resolved?.targetElement) return;
+        if (!InitialJumpUtils.shouldRunTimelineJump({
+            targetId: resolved.targetId,
+            activeTurnId: this.activeTurnId,
+            initialJumpReady: this.initialJumpReady
+        })) {
+            this.pendingInitialJump = null;
+            return;
+        }
         this.activeTurnId = resolved.targetId;
         this.pendingActiveId = null;
         this.updateActiveDotUI();
@@ -980,16 +1000,19 @@ class TimelineManager {
         this.lockScrollAnchoring();
         const session = this.smoothScrollSession;
         const container = this.scrollContainer;
-        const targetPosition = this.getTargetScrollTop(targetElement);
-        if (!Number.isFinite(targetPosition)) {
-            this.unlockScrollAnchoring();
-            return;
-        }
-        const startPosition = this.scrollContainer.scrollTop;
         const nowBase = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
         this.suppressActiveUntil = nowBase + duration + 1800;
+        const startPosition = this.scrollContainer.scrollTop;
+        const targetPosition = this.getTargetScrollTop(targetElement);
+        if (!Number.isFinite(targetPosition) || Math.abs(targetPosition - startPosition) <= 1) {
+            this.isScrolling = false;
+            this.smoothScrollRafId = null;
+            this.suppressActiveUntil = 0;
+            this.unlockScrollAnchoring();
+            this.scheduleScrollSync();
+            return;
+        }
         let startTime = null;
-
         const animation = (currentTime) => {
             if (session !== this.smoothScrollSession || !this.scrollContainer || this.scrollContainer !== container) return;
             this.isScrolling = true;
@@ -1337,8 +1360,13 @@ class TimelineManager {
         const pad = this.getTrackPadding();
         const minGap = this.getMinGap();
         const N = this.markers.length;
-        // Content height ensures minGap between consecutive dots
-        const desired = Math.max(H, (N > 0 ? (2 * pad + Math.max(0, N - 1) * minGap) : H));
+        const markerRatios = this.markers.map(marker => marker.baseN ?? marker.n ?? 0);
+        const desired = InitialJumpUtils.calculateTimelineContentHeight({
+            viewportHeight: H,
+            padding: pad,
+            minGap,
+            markerRatios
+        });
         this.contentHeight = Math.ceil(desired);
         this.scale = (H > 0) ? (this.contentHeight / H) : 1;
         try { this.ui.trackContent.style.height = `${this.contentHeight}px`; } catch {}
@@ -1399,9 +1427,13 @@ class TimelineManager {
         if (!this.ui.track || !this.scrollContainer || !this.contentHeight) return;
         const scrollTop = this.scrollContainer.scrollTop;
         const ref = this.getActiveReferenceY(scrollTop);
-        this.refreshMarkerScrollPositions();
-        const span = Math.max(1, this.contentSpanPx || 1);
-        const r = Math.max(0, Math.min(1, (ref - (this.firstUserTurnOffset || 0)) / span));
+        const livePositions = this.refreshMarkerScrollPositions();
+        const visualRatios = this.markers.map(marker => marker.baseN ?? marker.n ?? 0);
+        const r = InitialJumpUtils.mapLiveReferenceToVisualRatio({
+            livePositions,
+            visualRatios,
+            referenceY: ref
+        });
         const maxScroll = Math.max(0, this.contentHeight - (this.ui.track.clientHeight || 0));
         const target = Math.round(r * maxScroll);
         if (Math.abs((this.ui.track.scrollTop || 0) - target) > 1) {
@@ -1452,6 +1484,7 @@ class TimelineManager {
                 dot.dataset.targetTurnId = marker.id;
                 dot.setAttribute('aria-label', marker.summary);
                 dot.setAttribute('tabindex', '0');
+                dot.setAttribute('type', 'button');
                 try { dot.setAttribute('aria-describedby', 'chatgpt-timeline-tooltip'); } catch {}
                 try { dot.style.setProperty('--n', String(marker.n || 0)); } catch {}
                 if (this.usePixelTop) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,7 @@
         "https://chatgpt.com/*",
         "https://chat.openai.com/*"
       ],
-      "js": ["content-chatgpt.js"],
+      "js": ["chatgpt-initial-jump-utils.js", "content-chatgpt.js"],
       "css": ["styles-chatgpt.css"]
     },
     {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -3,7 +3,6 @@ const assert = require('node:assert/strict');
 const {
   evaluateInitialJumpReadiness,
   evaluateScrollCorrection,
-  normalizeMarkerPositions,
   pickBestScrollableCandidate,
   resolveActiveReferenceY,
   resolveScrollAnchoring,
@@ -130,19 +129,6 @@ run('evaluateScrollCorrection keeps correcting until the target is stable', () =
     needsWrite: false,
     shouldContinue: false
   });
-});
-
-run('normalizeMarkerPositions remaps visual spacing from live measured positions', () => {
-  assert.deepEqual(normalizeMarkerPositions({
-    positions: [100, 250, 700]
-  }), [0, 0.25, 1]);
-});
-
-run('normalizeMarkerPositions preserves previous values when live positions are invalid', () => {
-  assert.deepEqual(normalizeMarkerPositions({
-    positions: [100, NaN, 700],
-    previous: [0, 0.5, 1]
-  }), [0, 0.5, 1]);
 });
 
 run('pickBestScrollableCandidate prefers the nearest real non-document scroll root', () => {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -1,0 +1,140 @@
+const assert = require('node:assert/strict');
+
+const {
+  evaluateInitialJumpReadiness,
+  evaluateScrollCorrection,
+  pickBestScrollableCandidate,
+  resolveActiveReferenceY,
+  resolveScrollAnchoring,
+  resolveScrollFocusOffset,
+  resolveScrollTarget,
+  selectActiveIndex
+} = require('../extension/chatgpt-initial-jump-utils.js');
+
+function run(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+run('evaluateInitialJumpReadiness keeps initial jumps blocked while layout metrics move', () => {
+  assert.deepEqual(evaluateInitialJumpReadiness({
+    stableFrames: 2,
+    previousScrollTop: 120,
+    currentScrollTop: 124,
+    previousScrollHeight: 5000,
+    currentScrollHeight: 5080,
+    previousAnchorTop: 800,
+    currentAnchorTop: 812
+  }), {
+    frameStable: false,
+    stableFrames: 0,
+    ready: false
+  });
+});
+
+run('evaluateInitialJumpReadiness allows initial jumps after enough stable frames', () => {
+  assert.deepEqual(evaluateInitialJumpReadiness({
+    stableFrames: 3,
+    previousScrollTop: 120,
+    currentScrollTop: 121,
+    previousScrollHeight: 5000,
+    currentScrollHeight: 5001,
+    previousAnchorTop: 800,
+    currentAnchorTop: 801,
+    requiredStableFrames: 4
+  }), {
+    frameStable: true,
+    stableFrames: 4,
+    ready: true
+  });
+});
+
+run('evaluateInitialJumpReadiness waits for the minimum initial settle window', () => {
+  assert.deepEqual(evaluateInitialJumpReadiness({
+    stableFrames: 3,
+    previousScrollTop: 120,
+    currentScrollTop: 121,
+    previousScrollHeight: 5000,
+    currentScrollHeight: 5001,
+    previousAnchorTop: 800,
+    currentAnchorTop: 801,
+    requiredStableFrames: 4,
+    elapsedMs: 100,
+    minReadyMs: 250
+  }), {
+    frameStable: true,
+    stableFrames: 4,
+    ready: false
+  });
+});
+
+run('resolveScrollAnchoring disables and restores host scroll anchoring around controlled jumps', () => {
+  assert.equal(resolveScrollAnchoring({ active: true, fallback: 'auto' }), 'none');
+  assert.equal(resolveScrollAnchoring({ active: false, fallback: 'auto' }), 'auto');
+  assert.equal(resolveScrollAnchoring({ active: false, fallback: '' }), '');
+});
+
+run('resolveScrollFocusOffset prefers container scroll padding and keeps a small gap', () => {
+  assert.equal(resolveScrollFocusOffset({
+    containerScrollPaddingTop: 64,
+    fallbackOffset: 2,
+    gapOffset: 12
+  }), 76);
+});
+
+run('resolveScrollTarget subtracts the shared focus offset from raw target top', () => {
+  assert.equal(resolveScrollTarget({
+    rawTop: 1000,
+    focusOffset: 76
+  }), 924);
+});
+
+run('resolveActiveReferenceY uses the same focus line as controlled jumps', () => {
+  assert.equal(resolveActiveReferenceY({
+    scrollTop: 924,
+    focusOffset: 76,
+    epsilon: 2
+  }), 1002);
+});
+
+run('selectActiveIndex uses measured live positions instead of stale visible hints', () => {
+  assert.equal(selectActiveIndex({
+    positions: [100, 300, 900],
+    visibleIndices: [0],
+    referenceY: 920
+  }), 2);
+});
+
+run('evaluateScrollCorrection keeps correcting until the target is stable', () => {
+  assert.deepEqual(evaluateScrollCorrection({
+    delta: 8,
+    stableFrames: 0,
+    now: 100,
+    deadline: 500
+  }), {
+    needsWrite: true,
+    shouldContinue: true
+  });
+  assert.deepEqual(evaluateScrollCorrection({
+    delta: 1,
+    stableFrames: 6,
+    now: 200,
+    deadline: 500
+  }), {
+    needsWrite: false,
+    shouldContinue: false
+  });
+});
+
+run('pickBestScrollableCandidate prefers the nearest real non-document scroll root', () => {
+  assert.equal(pickBestScrollableCandidate([
+    { key: 'inner', overflow: 500, isDocument: false, depth: 1 },
+    { key: 'outer', overflow: 5000, isDocument: false, depth: 3 },
+    { key: 'document', overflow: 10000, isDocument: true, depth: 99 }
+  ]).key, 'inner');
+});

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -3,11 +3,15 @@ const assert = require('node:assert/strict');
 const {
   evaluateInitialJumpReadiness,
   evaluateScrollCorrection,
+  calculateTimelineContentHeight,
+  mapLiveReferenceToVisualRatio,
+  normalizeMarkerRatios,
   pickBestScrollableCandidate,
   resolveActiveReferenceY,
   resolveScrollAnchoring,
   resolveScrollFocusOffset,
   resolveScrollTarget,
+  shouldRunTimelineJump,
   selectActiveIndex
 } = require('../extension/chatgpt-initial-jump-utils.js');
 
@@ -102,6 +106,30 @@ run('resolveActiveReferenceY uses the same focus line as controlled jumps', () =
   }), 1002);
 });
 
+run('shouldRunTimelineJump ignores first-load clicks on the already active marker', () => {
+  assert.equal(shouldRunTimelineJump({
+    targetId: 'turn-4',
+    activeTurnId: 'turn-4',
+    initialJumpReady: false
+  }), false);
+});
+
+run('shouldRunTimelineJump still allows first-load clicks on a different marker', () => {
+  assert.equal(shouldRunTimelineJump({
+    targetId: 'turn-2',
+    activeTurnId: 'turn-4',
+    initialJumpReady: false
+  }), true);
+});
+
+run('shouldRunTimelineJump ignores clicks on the already active marker after readiness', () => {
+  assert.equal(shouldRunTimelineJump({
+    targetId: 'turn-4',
+    activeTurnId: 'turn-4',
+    initialJumpReady: true
+  }), false);
+});
+
 run('selectActiveIndex uses measured live positions instead of stale visible hints', () => {
   assert.equal(selectActiveIndex({
     positions: [100, 300, 900],
@@ -129,6 +157,89 @@ run('evaluateScrollCorrection keeps correcting until the target is stable', () =
     needsWrite: false,
     shouldContinue: false
   });
+});
+
+run('normalizeMarkerRatios preserves live anchor interval proportions', () => {
+  const ratios = normalizeMarkerRatios({
+    positions: [120, 420, 1620, 2220]
+  });
+  assert.deepEqual(ratios, [0, 1 / 7, 5 / 7, 1]);
+});
+
+run('normalizeMarkerRatios keeps previous stable ratios when live anchors are incomplete', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [120, NaN, 2220],
+    previous: [0, 0.4, 1]
+  }), [0, 0.4, 1]);
+});
+
+run('normalizeMarkerRatios keeps previous stable ratios when live anchors are not monotonic', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [120, 620, 590, 2220],
+    previous: [0, 0.24, 0.48, 1]
+  }), [0, 0.24, 0.48, 1]);
+});
+
+run('normalizeMarkerRatios falls back to zeros when bad anchors have no stable previous ratios', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [120, 620, 590, 2220],
+    previous: [undefined, undefined, undefined, undefined]
+  }), [0, 0, 0, 0]);
+});
+
+run('normalizeMarkerRatios keeps previous stable ratios when a delayed rebuild is severely skewed', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [100, 200, 300, 1300],
+    previous: [0, 1 / 3, 2 / 3, 1],
+    preservePreviousOnSkew: true
+  }), [0, 1 / 3, 2 / 3, 1]);
+});
+
+run('normalizeMarkerRatios accepts skewed ratios when there is no previous stable shape', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [100, 200, 300, 1300],
+    preservePreviousOnSkew: true
+  }), [0, 1 / 12, 1 / 6, 1]);
+});
+
+run('mapLiveReferenceToVisualRatio maps live scroll references onto stable visual spacing', () => {
+  const ratio = mapLiveReferenceToVisualRatio({
+    livePositions: [100, 300, 900],
+    visualRatios: [0, 0.2, 1],
+    referenceY: 600
+  });
+  assert.ok(Math.abs(ratio - 0.6) < 0.0001);
+});
+
+run('mapLiveReferenceToVisualRatio clamps outside the measured live range', () => {
+  assert.equal(mapLiveReferenceToVisualRatio({
+    livePositions: [100, 300, 900],
+    visualRatios: [0, 0.2, 1],
+    referenceY: 50
+  }), 0);
+  assert.equal(mapLiveReferenceToVisualRatio({
+    livePositions: [100, 300, 900],
+    visualRatios: [0, 0.2, 1],
+    referenceY: 1200
+  }), 1);
+});
+
+run('calculateTimelineContentHeight expands dense proportional spacing before min-gap adjustment', () => {
+  assert.equal(calculateTimelineContentHeight({
+    viewportHeight: 651,
+    padding: 16,
+    minGap: 24,
+    markerRatios: [0, 0.032, 0.21, 0.3, 1]
+  }), 782);
+});
+
+run('calculateTimelineContentHeight keeps the viewport height when proportional spacing already fits', () => {
+  assert.equal(calculateTimelineContentHeight({
+    viewportHeight: 651,
+    padding: 16,
+    minGap: 24,
+    markerRatios: [0, 0.25, 0.5, 0.75, 1]
+  }), 651);
 });
 
 run('pickBestScrollableCandidate prefers the nearest real non-document scroll root', () => {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -202,6 +202,13 @@ run('normalizeMarkerRatios accepts skewed ratios when there is no previous stabl
   }), [0, 1 / 12, 1 / 6, 1]);
 });
 
+run('normalizeMarkerRatios keeps a single marker renderable without a previous ratio', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [120],
+    previous: [undefined]
+  }), [0]);
+});
+
 run('mapLiveReferenceToVisualRatio maps live scroll references onto stable visual spacing', () => {
   const ratio = mapLiveReferenceToVisualRatio({
     livePositions: [100, 300, 900],

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const {
   evaluateInitialJumpReadiness,
   evaluateScrollCorrection,
+  normalizeMarkerPositions,
   pickBestScrollableCandidate,
   resolveActiveReferenceY,
   resolveScrollAnchoring,
@@ -129,6 +130,19 @@ run('evaluateScrollCorrection keeps correcting until the target is stable', () =
     needsWrite: false,
     shouldContinue: false
   });
+});
+
+run('normalizeMarkerPositions remaps visual spacing from live measured positions', () => {
+  assert.deepEqual(normalizeMarkerPositions({
+    positions: [100, 250, 700]
+  }), [0, 0.25, 1]);
+});
+
+run('normalizeMarkerPositions preserves previous values when live positions are invalid', () => {
+  assert.deepEqual(normalizeMarkerPositions({
+    positions: [100, NaN, 700],
+    previous: [0, 0.5, 1]
+  }), [0, 0.5, 1]);
 });
 
 run('pickBestScrollableCandidate prefers the nearest real non-document scroll root', () => {

--- a/tests/run-node-tests.ps1
+++ b/tests/run-node-tests.ps1
@@ -1,0 +1,1 @@
+node tests/chatgpt-initial-jump-utils.test.js


### PR DESCRIPTION
## Summary

Fixes a ChatGPT timeline jump issue in v3.2.0 where, on first entering a conversation page, clicking a timeline marker before any manual scroll could jump to the wrong message position.

This updates the ChatGPT timeline scroll logic to:

*   **Select the actual ChatGPT scroll root** more reliably.
*   **Measure marker positions** relative to live rendered message anchors.
*   **Account for scroll padding / sticky header offset** consistently.
*   **Keep target measurement live** during controlled smooth scrolling, preventing ChatGPT reflow or virtualization from using stale coordinates.

## Test Plan

*   `.\tests\run-node-tests.ps1`
*   `node --check extension\content-chatgpt.js`
*   `node --check extension\chatgpt-initial-jump-utils.js`
*   `git diff --check HEAD`
*   **Manual Test:** Open a long ChatGPT conversation, do not manually scroll, click timeline markers directly, and confirm jumps land on the correct message.