### PR TITLE
fix(chatgpt): 修复时间轴点位异常塌缩到顶部

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tests/
 .claude/
+extension.crx
+extension.pem

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -121,7 +121,15 @@
     const numericPositions = positions.map(position => Number(position));
     const previousRatios = previous.map(ratio => Number(ratio));
     const hasPrevious = previousRatios.length === positions.length && previousRatios.every(ratio => Number.isFinite(ratio));
-    const fallback = () => hasPrevious ? previous.slice() : positions.map(() => 0);
+    const readableFallback = () => {
+      if (positions.length <= 1) return positions.map(() => 0);
+      return positions.map((_, index) => index / Math.max(1, positions.length - 1));
+    };
+    const hasUsablePrevious = hasPrevious && (
+      positions.length <= 1 ||
+      previousRatios[previousRatios.length - 1] > previousRatios[0]
+    );
+    const fallback = () => hasUsablePrevious ? previousRatios.slice() : readableFallback();
     if (numericPositions.some(position => !Number.isFinite(position))) {
       return fallback();
     }

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -178,8 +178,7 @@
       const candidateMax = Math.max(...candidateGaps);
       const candidateMin = Math.min(...candidateGaps.filter(gap => gap > 0));
       const candidateSpread = candidateMin > 0 ? candidateMax / candidateMin : Infinity;
-      const lowConfidenceVirtualCount = normalized.length <= 12;
-      if (lowConfidenceVirtualCount && candidateSpread > 6) {
+      if (candidateSpread > 6) {
         if (!hasPrevious) return readableFallback();
         const previousGaps = gaps(previousRatios);
         const previousMax = Math.max(...previousGaps);

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -178,7 +178,7 @@
       const candidateMax = Math.max(...candidateGaps);
       const candidateMin = Math.min(...candidateGaps.filter(gap => gap > 0));
       const candidateSpread = candidateMin > 0 ? candidateMax / candidateMin : Infinity;
-      const lowConfidenceVirtualCount = normalized.length <= 4 || (normalized.length >= 6 && normalized.length <= 12);
+      const lowConfidenceVirtualCount = normalized.length <= 12;
       if (lowConfidenceVirtualCount && candidateSpread > 6) {
         if (!hasPrevious) return readableFallback();
         const previousGaps = gaps(previousRatios);

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -115,7 +115,14 @@
     const targetId = String(input.targetId || '').trim();
     const activeTurnId = String(input.activeTurnId || '').trim();
     if (!targetId) return false;
-    if (activeTurnId && targetId === activeTurnId) return false;
+    if (activeTurnId && targetId === activeTurnId) {
+      if (!input.initialJumpReady) return false;
+      const currentScrollTop = Number(input.currentScrollTop);
+      const targetScrollTop = Number(input.targetScrollTop);
+      const epsilon = Math.max(0, Number(input.epsilon) || 2);
+      if (!Number.isFinite(currentScrollTop) || !Number.isFinite(targetScrollTop)) return false;
+      return Math.abs(targetScrollTop - currentScrollTop) > epsilon;
+    }
     return true;
   }
 

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -96,7 +96,12 @@
     const rawTop = Number(input.rawTop);
     const focusOffset = Math.max(0, Number(input.focusOffset) || 0);
     if (!Number.isFinite(rawTop)) return NaN;
-    return rawTop - focusOffset;
+    const target = rawTop - focusOffset;
+    const maxScrollTop = Number(input.maxScrollTop);
+    if (Number.isFinite(maxScrollTop) && maxScrollTop >= 0) {
+      return Math.max(0, Math.min(target, maxScrollTop));
+    }
+    return target;
   }
 
   function resolveActiveReferenceY(input = {}) {
@@ -112,6 +117,18 @@
     if (!targetId) return false;
     if (activeTurnId && targetId === activeTurnId) return false;
     return true;
+  }
+
+  function normalizeChatGPTTurnText(text) {
+    try {
+      let value = String(text || '').replace(/\s+/g, ' ').trim();
+      value = value.replace(/^\s*(you\s*said\s*[:：]?\s*)/i, '');
+      value = value.replace(/^\s*((你说|您说|你說|您說)\s*[:：]?\s*)/, '');
+      value = value.replace(/(?:\s*(?:show\s+more|show\s+less|显示更多|顯示更多|显示较少|顯示較少|收起))+$/i, '').trim();
+      return value;
+    } catch {
+      return '';
+    }
   }
 
   function normalizeMarkerRatios(input = {}) {
@@ -151,22 +168,32 @@
       const normalized = (position - first) / span;
       return Math.max(0, Math.min(1, normalized));
     });
-    if (input.preservePreviousOnSkew && hasPrevious && normalized.length >= 4) {
+    if (normalized.length >= 4) {
       const gaps = ratios => {
         const out = [];
         for (let i = 1; i < ratios.length; i++) out.push(Math.max(0, Number(ratios[i]) - Number(ratios[i - 1])));
         return out;
       };
       const candidateGaps = gaps(normalized);
-      const previousGaps = gaps(previousRatios);
       const candidateMax = Math.max(...candidateGaps);
       const candidateMin = Math.min(...candidateGaps.filter(gap => gap > 0));
-      const previousMax = Math.max(...previousGaps);
-      const previousMin = Math.min(...previousGaps.filter(gap => gap > 0));
       const candidateSpread = candidateMin > 0 ? candidateMax / candidateMin : Infinity;
-      const previousSpread = previousMin > 0 ? previousMax / previousMin : Infinity;
-      if (Number.isFinite(previousSpread) && candidateSpread > Math.max(6, previousSpread * 4)) {
-        return previous.slice();
+      if (normalized.length <= 4 && candidateSpread > 6) {
+        if (!hasPrevious) return readableFallback();
+        const previousGaps = gaps(previousRatios);
+        const previousMax = Math.max(...previousGaps);
+        const previousMin = Math.min(...previousGaps.filter(gap => gap > 0));
+        const previousSpread = previousMin > 0 ? previousMax / previousMin : Infinity;
+        if (previousSpread > 6) return readableFallback();
+      }
+      if (input.preservePreviousOnSkew && hasPrevious) {
+        const previousGaps = gaps(previousRatios);
+        const previousMax = Math.max(...previousGaps);
+        const previousMin = Math.min(...previousGaps.filter(gap => gap > 0));
+        const previousSpread = previousMin > 0 ? previousMax / previousMin : Infinity;
+        if (Number.isFinite(previousSpread) && candidateSpread > Math.max(6, previousSpread * 4)) {
+          return previous.slice();
+        }
       }
     }
     return normalized;
@@ -228,7 +255,8 @@
       previous = clamped;
     }
 
-    if (Number.isFinite(minRatioGap) && minRatioGap > 0 && minGap > 0) {
+    const sparseVirtualSample = markerCount <= 4;
+    if (!sparseVirtualSample && Number.isFinite(minRatioGap) && minRatioGap > 0 && minGap > 0) {
       desired = Math.max(desired, 2 * padding + minGap / minRatioGap);
     }
 
@@ -239,6 +267,18 @@
     const positions = Array.isArray(input.positions) ? input.positions : [];
     const referenceY = Number(input.referenceY);
     if (!positions.length || !Number.isFinite(referenceY)) return 0;
+    const scrollTop = Number(input.scrollTop);
+    const clientHeight = Number(input.clientHeight);
+    const scrollHeight = Number(input.scrollHeight);
+    const bottomEpsilon = Math.max(0, Number(input.bottomEpsilon) || 4);
+    if (
+      Number.isFinite(scrollTop) &&
+      Number.isFinite(clientHeight) &&
+      Number.isFinite(scrollHeight) &&
+      scrollHeight - (scrollTop + clientHeight) <= bottomEpsilon
+    ) {
+      return positions.length - 1;
+    }
     let active = 0;
     for (let i = 0; i < positions.length; i++) {
       const position = Number(positions[i]);
@@ -261,6 +301,7 @@
     resolveScrollAnchoring,
     resolveScrollFocusOffset,
     resolveScrollTarget,
+    normalizeChatGPTTurnText,
     selectActiveIndex
   };
 });

--- a/extension/chatgpt-initial-jump-utils.js
+++ b/extension/chatgpt-initial-jump-utils.js
@@ -178,7 +178,8 @@
       const candidateMax = Math.max(...candidateGaps);
       const candidateMin = Math.min(...candidateGaps.filter(gap => gap > 0));
       const candidateSpread = candidateMin > 0 ? candidateMax / candidateMin : Infinity;
-      if (normalized.length <= 4 && candidateSpread > 6) {
+      const lowConfidenceVirtualCount = normalized.length <= 4 || (normalized.length >= 6 && normalized.length <= 12);
+      if (lowConfidenceVirtualCount && candidateSpread > 6) {
         if (!hasPrevious) return readableFallback();
         const previousGaps = gaps(previousRatios);
         const previousMax = Math.max(...previousGaps);

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -73,6 +73,9 @@ class TimelineManager {
         // Debug perf
         this.debugPerf = false;
         try { this.debugPerf = (localStorage.getItem('chatgptTimelineDebugPerf') === '1'); } catch {}
+        this.debugLayout = false;
+        try { this.debugLayout = (localStorage.getItem('chatgptTimelineDebugLayout') === '1'); } catch {}
+        this.lastLayoutDebugKey = '';
         this.onVisualViewportResize = null;
         
         this.debouncedRecalculateAndRender = this.debounce(this.recalculateAndRenderMarkers, 350);
@@ -834,8 +837,14 @@ class TimelineManager {
         const rawTop = targetRect.top - containerRect.top + this.scrollContainer.scrollTop;
         return InitialJumpUtils.resolveScrollTarget({
             rawTop,
-            focusOffset: this.getScrollFocusOffset()
+            focusOffset: this.getScrollFocusOffset(),
+            maxScrollTop: this.getMaxScrollTop()
         });
+    }
+
+    getMaxScrollTop() {
+        if (!this.scrollContainer) return 0;
+        return Math.max(0, (Number(this.scrollContainer.scrollHeight) || 0) - (Number(this.scrollContainer.clientHeight) || 0));
     }
 
     readComputedPixelValue(...values) {
@@ -1150,10 +1159,14 @@ class TimelineManager {
     // Normalize whitespace and trim; remove leading SR-only prefixes like "You said:" / "你说："; no manual ellipsis
     normalizeText(text) {
         try {
+            if (InitialJumpUtils?.normalizeChatGPTTurnText) {
+                return InitialJumpUtils.normalizeChatGPTTurnText(text);
+            }
             let s = String(text || '').replace(/\s+/g, ' ').trim();
             // Strip only if it appears at the very start
             s = s.replace(/^\s*(you\s*said\s*[:：]?\s*)/i, '');
             s = s.replace(/^\s*((你说|您说|你說|您說)\s*[:：]?\s*)/, '');
+            s = s.replace(/(?:\s*(?:show\s+more|show\s+less|显示更多|顯示更多|显示较少|顯示較少|收起))+$/i, '').trim();
             return s;
         } catch {
             return '';
@@ -1398,6 +1411,84 @@ class TimelineManager {
         } else {
             this.sliderAlwaysVisible = false;
         }
+        this.maybeLogLayoutDebug('geometry');
+    }
+
+    getRatioSpread(ratios) {
+        try {
+            const gaps = [];
+            for (let i = 1; i < ratios.length; i++) {
+                const gap = Number(ratios[i]) - Number(ratios[i - 1]);
+                if (Number.isFinite(gap) && gap > 0) gaps.push(gap);
+            }
+            if (!gaps.length) return { minGapRatio: null, maxGapRatio: null, spread: null };
+            const minGapRatio = Math.min(...gaps);
+            const maxGapRatio = Math.max(...gaps);
+            return {
+                minGapRatio,
+                maxGapRatio,
+                spread: minGapRatio > 0 ? maxGapRatio / minGapRatio : null
+            };
+        } catch {
+            return { minGapRatio: null, maxGapRatio: null, spread: null };
+        }
+    }
+
+    buildLayoutDebugSnapshot(stage) {
+        const barRect = this.ui.timelineBar?.getBoundingClientRect?.();
+        const trackRect = this.ui.track?.getBoundingClientRect?.();
+        const baseRatios = this.markers.map(marker => marker.baseN ?? marker.n ?? 0);
+        const renderedDots = Array.from(this.ui.trackContent?.querySelectorAll?.('.timeline-dot') || []).slice(0, 12).map(dot => {
+            const rect = dot.getBoundingClientRect();
+            return {
+                id: dot.dataset.targetTurnId || '',
+                cssN: dot.style.getPropertyValue('--n') || '',
+                topViewport: Math.round(rect.top * 10) / 10,
+                topInBar: barRect ? Math.round((rect.top - barRect.top + rect.height / 2) * 10) / 10 : null
+            };
+        });
+        return {
+            stage,
+            href: location.href,
+            markerCount: this.markers.length,
+            activeTurnId: this.activeTurnId,
+            scrollTop: Math.round(Number(this.scrollContainer?.scrollTop) || 0),
+            scrollHeight: Math.round(Number(this.scrollContainer?.scrollHeight) || 0),
+            barHeight: Math.round(barRect?.height || 0),
+            trackHeight: Math.round(trackRect?.height || 0),
+            trackScrollTop: Math.round(Number(this.ui.track?.scrollTop) || 0),
+            contentHeight: Math.round(this.contentHeight || 0),
+            scale: Math.round((this.scale || 0) * 1000) / 1000,
+            usePixelTop: !!this.usePixelTop,
+            cssVarTopSupported: this._cssVarTopSupported,
+            minGap: this.getMinGap(),
+            padding: this.getTrackPadding(),
+            ratioSpread: this.getRatioSpread(baseRatios),
+            positions: this.markerScrollPositions.map(value => Math.round(Number(value) || 0)),
+            baseRatios: baseRatios.map(value => Math.round((Number(value) || 0) * 10000) / 10000),
+            visualRatios: this.markers.map(marker => Math.round((Number(marker.n) || 0) * 10000) / 10000),
+            yPositions: this.yPositions.map(value => Math.round((Number(value) || 0) * 10) / 10),
+            visibleRange: { ...this.visibleRange },
+            renderedDots
+        };
+    }
+
+    maybeLogLayoutDebug(stage) {
+        try {
+            if (!this.markers.length) return;
+            if (!this.debugLayout) return;
+            const key = [
+                stage,
+                this.markers.length,
+                Math.round(this.contentHeight || 0),
+                this.yPositions.slice(0, 4).map(value => Math.round((Number(value) || 0) * 10) / 10).join(',')
+            ].join('|');
+            if (key === this.lastLayoutDebugKey) return;
+            this.lastLayoutDebugKey = key;
+            console.warn('[ChatGPT Timeline Layout Debug]', this.buildLayoutDebugSnapshot(stage));
+        } catch (error) {
+            console.warn('[ChatGPT Timeline Layout Debug failed]', error);
+        }
     }
 
     detectCssVarTopSupport(pad, usableC) {
@@ -1515,6 +1606,7 @@ class TimelineManager {
         this.visibleRange = { start, end };
         // keep slider in sync with timeline scroll
         this.updateSlider();
+        this.maybeLogLayoutDebug('render');
     }
 
     lowerBound(arr, x) {
@@ -1710,7 +1802,10 @@ class TimelineManager {
         const positions = this.refreshMarkerScrollPositions();
         const activeIndex = InitialJumpUtils.selectActiveIndex({
             positions,
-            referenceY: ref
+            referenceY: ref,
+            scrollTop,
+            clientHeight: this.scrollContainer.clientHeight,
+            scrollHeight: this.scrollContainer.scrollHeight
         });
         const activeId = this.markers[activeIndex]?.id || this.markers[0].id;
         if (this.activeTurnId !== activeId) {

--- a/extension/content-chatgpt.js
+++ b/extension/content-chatgpt.js
@@ -82,6 +82,7 @@ class TimelineManager {
 
         // Summary cache: retain text when ChatGPT virtualizes off-screen elements
         this.summaryCache = new Map();
+        this.summarySaveTimer = null;
         // Star/Highlight feature state
         this.starred = new Set();
         this.markerMap = new Map();
@@ -121,10 +122,11 @@ class TimelineManager {
         this.injectTimelineUI();
         this.setupEventListeners();
         this.setupObservers();
+        this.conversationId = this.extractConversationIdFromPath(location.pathname);
+        this.loadSummaries();
         // Force an immediate first build so dots appear without waiting for mutations
         try { this.recalculateAndRenderMarkers(); } catch {}
         // Load persisted star markers for current conversation
-        this.conversationId = this.extractConversationIdFromPath(location.pathname);
         this.loadStars();
         // After loading stars, sync current markers/dots to reflect star state immediately
         try {
@@ -625,6 +627,17 @@ class TimelineManager {
                 const cid = this.conversationId;
                 if (!cid) return;
                 const expectedKey = `chatgptTimelineStars:${cid}`;
+                const summaryKey = `chatgptTimelineSummaries:${cid}`;
+                if (e.key === summaryKey) {
+                    this.loadSummaries();
+                    for (const marker of this.markers) {
+                        const text = this.summaryCache.get(marker.id);
+                        if (!text) continue;
+                        marker.summary = text;
+                        try { marker.dotElement?.setAttribute('aria-label', text); } catch {}
+                    }
+                    return;
+                }
                 if (e.key !== expectedKey) return;
 
                 // Parse new star set
@@ -983,10 +996,13 @@ class TimelineManager {
     queueOrRunTimelineJump(targetId) {
         const resolved = this.resolvePendingJumpTarget({ targetId });
         if (!resolved?.targetElement) return;
+        const targetScrollTop = this.getTargetScrollTop(resolved.targetElement);
         if (!InitialJumpUtils.shouldRunTimelineJump({
             targetId: resolved.targetId,
             activeTurnId: this.activeTurnId,
-            initialJumpReady: this.initialJumpReady
+            initialJumpReady: this.initialJumpReady,
+            currentScrollTop: this.scrollContainer?.scrollTop,
+            targetScrollTop
         })) {
             this.pendingInitialJump = null;
             return;
@@ -1185,7 +1201,7 @@ class TimelineManager {
                 if (!data || typeof data !== 'object') return;
                 for (const id of Object.keys(data)) {
                     const text = this.normalizeText(data[id] || '');
-                    if (text) this.summaryCache.set(id, text);
+                    if (text) this.rememberSummary(id, text);
                 }
             };
             document.addEventListener('timeline-fiber-result', handler, { once: true });
@@ -1203,7 +1219,7 @@ class TimelineManager {
         const id = el.dataset.turnId;
         // Priority 1: DOM text (most reliable when element is not virtualized)
         const domText = this.normalizeText(el.textContent || '');
-        if (domText) { this.summaryCache.set(id, domText); return domText; }
+        if (domText) { this.rememberSummary(id, domText); return domText; }
         // Priority 2: cached value (filled by fiber bridge or previous DOM reads)
         return this.summaryCache.get(id) || '';
     }
@@ -1916,7 +1932,12 @@ class TimelineManager {
         this.ui.sliderHandle = null;
         this.ui = { timelineBar: null, tooltip: null };
         this.markers = [];
+        this.saveSummaries();
         this.summaryCache.clear();
+        if (this.summarySaveTimer) {
+            try { clearTimeout(this.summarySaveTimer); } catch {}
+            this.summarySaveTimer = null;
+        }
         this.activeTurnId = null;
         this.scrollContainer = null;
         this.conversationContainer = null;
@@ -1964,6 +1985,51 @@ class TimelineManager {
             const arr = JSON.parse(raw);
             if (Array.isArray(arr)) arr.forEach(id => this.starred.add(String(id)));
         } catch {}
+    }
+
+    loadSummaries() {
+        this.summaryCache.clear();
+        const cid = this.conversationId;
+        if (!cid) return;
+        try {
+            const raw = localStorage.getItem(`chatgptTimelineSummaries:${cid}`);
+            if (!raw) return;
+            const data = JSON.parse(raw);
+            if (!data || typeof data !== 'object' || Array.isArray(data)) return;
+            Object.keys(data).forEach(id => {
+                const text = this.normalizeText(data[id] || '');
+                if (text) this.summaryCache.set(String(id), text);
+            });
+        } catch {}
+    }
+
+    saveSummaries() {
+        const cid = this.conversationId;
+        if (!cid) return;
+        try {
+            const entries = Array.from(this.summaryCache.entries())
+                .filter(([id, text]) => id && text)
+                .slice(-500);
+            localStorage.setItem(`chatgptTimelineSummaries:${cid}`, JSON.stringify(Object.fromEntries(entries)));
+        } catch {}
+    }
+
+    scheduleSummarySave() {
+        if (this.summarySaveTimer) return;
+        this.summarySaveTimer = setTimeout(() => {
+            this.summarySaveTimer = null;
+            this.saveSummaries();
+        }, 250);
+    }
+
+    rememberSummary(id, text) {
+        const key = String(id || '').trim();
+        const value = this.normalizeText(text || '');
+        if (!key || !value) return false;
+        if (this.summaryCache.get(key) === value) return false;
+        this.summaryCache.set(key, value);
+        this.scheduleSummarySave();
+        return true;
     }
 
     saveStars() {

--- a/extension/fiber-bridge-chatgpt.js
+++ b/extension/fiber-bridge-chatgpt.js
@@ -6,16 +6,41 @@
 document.addEventListener('timeline-extract-fiber', () => {
   try {
     const result = {};
-    document.querySelectorAll('[data-turn="user"][data-turn-id]').forEach(el => {
-      if (el.childElementCount > 0) return; // has DOM content, skip
+    const extractTextFromValue = (value, depth = 0, seen = new Set()) => {
+      if (!value || depth > 8) return '';
+      if (typeof value === 'string') return value;
+      if (typeof value !== 'object') return '';
+      if (seen.has(value)) return '';
+      seen.add(value);
+
       try {
+        const parts = value?.content?.parts || value?.message?.content?.parts;
+        if (Array.isArray(parts)) {
+          const text = parts.filter(p => typeof p === 'string').join(' ');
+          if (text) return text;
+        }
+        const messages = value?.turn?.messages || value?.messages;
+        if (Array.isArray(messages)) {
+          for (const message of messages) {
+            const text = extractTextFromValue(message, depth + 1, seen);
+            if (text) return text;
+          }
+        }
+        for (const key of ['memoizedProps', 'pendingProps', 'return', 'child', 'sibling']) {
+          const text = extractTextFromValue(value[key], depth + 1, seen);
+          if (text) return text;
+        }
+      } catch {}
+      return '';
+    };
+
+    document.querySelectorAll('[data-turn="user"][data-turn-id]').forEach(el => {
+      try {
+        const domText = String(el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+        if (domText) return;
         const fk = Object.keys(el).find(k => k.startsWith('__reactFiber'));
         if (!fk) return;
-        const turn = el[fk]?.return?.memoizedProps?.turn;
-        if (!turn?.messages?.length) return;
-        const parts = turn.messages[0]?.content?.parts;
-        if (!Array.isArray(parts)) return;
-        const txt = parts.filter(p => typeof p === 'string').join(' ');
+        const txt = extractTextFromValue(el[fk]);
         if (txt) result[el.getAttribute('data-turn-id')] = txt;
       } catch {}
     });

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -180,11 +180,18 @@ run('normalizeMarkerRatios keeps previous stable ratios when live anchors are no
   }), [0, 0.24, 0.48, 1]);
 });
 
-run('normalizeMarkerRatios falls back to zeros when bad anchors have no stable previous ratios', () => {
+run('normalizeMarkerRatios falls back to readable spacing when bad anchors have no stable previous ratios', () => {
   assert.deepEqual(normalizeMarkerRatios({
     positions: [120, 620, 590, 2220],
     previous: [undefined, undefined, undefined, undefined]
-  }), [0, 0, 0, 0]);
+  }), [0, 1 / 3, 2 / 3, 1]);
+});
+
+run('normalizeMarkerRatios does not preserve a collapsed previous shape', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [120, 620, 590],
+    previous: [0, 0, 0]
+  }), [0, 0.5, 1]);
 });
 
 run('normalizeMarkerRatios keeps previous stable ratios when a delayed rebuild is severely skewed', () => {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -245,6 +245,12 @@ run('normalizeMarkerRatios falls back for first sparse skewed virtual sample wit
   }), [0, 1 / 3, 2 / 3, 1]);
 });
 
+run('normalizeMarkerRatios uses uniform directory spacing for low-confidence virtual samples', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [0, 720, 1440, 2160, 2880, 10000, 18591]
+  }), [0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6, 1]);
+});
+
 run('normalizeMarkerRatios does not preserve a sparse skewed previous virtual shape', () => {
   assert.deepEqual(normalizeMarkerRatios({
     positions: [110, 210, 310, 1310],

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -251,6 +251,12 @@ run('normalizeMarkerRatios uses uniform directory spacing for low-confidence vir
   }), [0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6, 1]);
 });
 
+run('normalizeMarkerRatios uses uniform directory spacing for five-marker virtual samples', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [0, 707, 1427, 13005, 16272]
+  }), [0, 0.25, 0.5, 0.75, 1]);
+});
+
 run('normalizeMarkerRatios does not preserve a sparse skewed previous virtual shape', () => {
   assert.deepEqual(normalizeMarkerRatios({
     positions: [110, 210, 310, 1310],
@@ -259,11 +265,12 @@ run('normalizeMarkerRatios does not preserve a sparse skewed previous virtual sh
   }), [0, 1 / 3, 2 / 3, 1]);
 });
 
-run('normalizeMarkerRatios accepts skewed ratios once the sample is dense enough', () => {
+run('normalizeMarkerRatios accepts skewed ratios once the sample is large enough', () => {
+  const positions = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1300, 1600];
   assert.deepEqual(normalizeMarkerRatios({
-    positions: [100, 200, 300, 1300, 1600],
+    positions,
     preservePreviousOnSkew: true
-  }), [0, 1 / 15, 2 / 15, 12 / 15, 1]);
+  }), positions.map(position => (position - 100) / 1500));
 });
 
 run('normalizeMarkerRatios keeps a single marker renderable without a previous ratio', () => {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -257,6 +257,13 @@ run('normalizeMarkerRatios uses uniform directory spacing for five-marker virtua
   }), [0, 0.25, 0.5, 0.75, 1]);
 });
 
+run('normalizeMarkerRatios uses uniform directory spacing for high-count low-confidence virtual samples', () => {
+  const positions = [0, 707, 1427, 2144, 2860, 3575, 4292, 5009, 5725, 6440, 7158, 7874, 8591, 18000, 22000];
+  assert.deepEqual(normalizeMarkerRatios({
+    positions
+  }), positions.map((_, index) => index / (positions.length - 1)));
+});
+
 run('normalizeMarkerRatios does not preserve a sparse skewed previous virtual shape', () => {
   assert.deepEqual(normalizeMarkerRatios({
     positions: [110, 210, 310, 1310],

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -12,7 +12,8 @@ const {
   resolveScrollFocusOffset,
   resolveScrollTarget,
   shouldRunTimelineJump,
-  selectActiveIndex
+  selectActiveIndex,
+  normalizeChatGPTTurnText
 } = require('../extension/chatgpt-initial-jump-utils.js');
 
 function run(name, fn) {
@@ -98,6 +99,14 @@ run('resolveScrollTarget subtracts the shared focus offset from raw target top',
   }), 924);
 });
 
+run('resolveScrollTarget clamps unreachable bottom targets to the maximum scroll top', () => {
+  assert.equal(resolveScrollTarget({
+    rawTop: 21800,
+    focusOffset: 76,
+    maxScrollTop: 21214
+  }), 21214);
+});
+
 run('resolveActiveReferenceY uses the same focus line as controlled jumps', () => {
   assert.equal(resolveActiveReferenceY({
     scrollTop: 924,
@@ -130,11 +139,32 @@ run('shouldRunTimelineJump ignores clicks on the already active marker after rea
   }), false);
 });
 
+run('normalizeChatGPTTurnText removes trailing ChatGPT collapse control labels', () => {
+  assert.equal(
+    normalizeChatGPTTurnText('你现在可以 grill me 或者向我泼冷水/质疑这个方案 Show more Show less'),
+    '你现在可以 grill me 或者向我泼冷水/质疑这个方案'
+  );
+  assert.equal(
+    normalizeChatGPTTurnText('You said: keep the real message Show moreShow less'),
+    'keep the real message'
+  );
+});
+
 run('selectActiveIndex uses measured live positions instead of stale visible hints', () => {
   assert.equal(selectActiveIndex({
     positions: [100, 300, 900],
     visibleIndices: [0],
     referenceY: 920
+  }), 2);
+});
+
+run('selectActiveIndex chooses the last marker at the scroll bottom', () => {
+  assert.equal(selectActiveIndex({
+    positions: [100, 300, 900],
+    referenceY: 650,
+    scrollTop: 1200,
+    clientHeight: 600,
+    scrollHeight: 1800
   }), 2);
 });
 
@@ -202,11 +232,32 @@ run('normalizeMarkerRatios keeps previous stable ratios when a delayed rebuild i
   }), [0, 1 / 3, 2 / 3, 1]);
 });
 
-run('normalizeMarkerRatios accepts skewed ratios when there is no previous stable shape', () => {
+run('normalizeMarkerRatios falls back to readable spacing for sparse skewed virtual samples', () => {
   assert.deepEqual(normalizeMarkerRatios({
     positions: [100, 200, 300, 1300],
     preservePreviousOnSkew: true
-  }), [0, 1 / 12, 1 / 6, 1]);
+  }), [0, 1 / 3, 2 / 3, 1]);
+});
+
+run('normalizeMarkerRatios falls back for first sparse skewed virtual sample without previous state', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [-12, 707, 7288, 18591]
+  }), [0, 1 / 3, 2 / 3, 1]);
+});
+
+run('normalizeMarkerRatios does not preserve a sparse skewed previous virtual shape', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [110, 210, 310, 1310],
+    previous: [0, 1 / 12, 1 / 6, 1],
+    preservePreviousOnSkew: true
+  }), [0, 1 / 3, 2 / 3, 1]);
+});
+
+run('normalizeMarkerRatios accepts skewed ratios once the sample is dense enough', () => {
+  assert.deepEqual(normalizeMarkerRatios({
+    positions: [100, 200, 300, 1300, 1600],
+    preservePreviousOnSkew: true
+  }), [0, 1 / 15, 2 / 15, 12 / 15, 1]);
 });
 
 run('normalizeMarkerRatios keeps a single marker renderable without a previous ratio', () => {
@@ -254,6 +305,24 @@ run('calculateTimelineContentHeight keeps the viewport height when proportional 
     minGap: 24,
     markerRatios: [0, 0.25, 0.5, 0.75, 1]
   }), 651);
+});
+
+run('calculateTimelineContentHeight avoids huge expansion for sparse virtualized marker samples', () => {
+  assert.equal(calculateTimelineContentHeight({
+    viewportHeight: 651,
+    padding: 16,
+    minGap: 24,
+    markerRatios: [0, 0.003, 0.21, 1]
+  }), 651);
+});
+
+run('calculateTimelineContentHeight avoids slight overflow for sparse virtual samples', () => {
+  assert.equal(calculateTimelineContentHeight({
+    viewportHeight: 619,
+    padding: 16,
+    minGap: 24,
+    markerRatios: [0, 0.038664564953497634, 0.3923946554639225, 1]
+  }), 619);
 });
 
 run('pickBestScrollableCandidate prefers the nearest real non-document scroll root', () => {

--- a/tests/chatgpt-initial-jump-utils.test.js
+++ b/tests/chatgpt-initial-jump-utils.test.js
@@ -139,6 +139,16 @@ run('shouldRunTimelineJump ignores clicks on the already active marker after rea
   }), false);
 });
 
+run('shouldRunTimelineJump allows active marker clicks when the page is not at its target', () => {
+  assert.equal(shouldRunTimelineJump({
+    targetId: 'turn-4',
+    activeTurnId: 'turn-4',
+    initialJumpReady: true,
+    currentScrollTop: 1600,
+    targetScrollTop: 2200
+  }), true);
+});
+
 run('normalizeChatGPTTurnText removes trailing ChatGPT collapse control labels', () => {
   assert.equal(
     normalizeChatGPTTurnText('你现在可以 grill me 或者向我泼冷水/质疑这个方案 Show more Show less'),


### PR DESCRIPTION
## 概述

这是我上一个已合并 PR（`fix(chatgpt): stabilize initial timeline jumps (#34)`）的 follow-up 修复。

最初这个 PR 只针对一个边缘问题：ChatGPT 初始渲染时，用户消息锚点测量短暂无效或非递增，导致时间轴 marker fallback 成塌缩比例，例如 `[0, 0, 0]`，从而所有点挤到顶部。

在后续测试中，我发现 ChatGPT 网页最近引入/加强了虚拟滚动行为：首次进入较长会话时，上方历史消息可能还没有加载完成，但页面已经能测到部分用户消息锚点。这会产生低可信、严重偏斜的 DOM 位置比例，导致时间轴点位出现不自然的挤压、过长内部滚动轴，或底部 active marker 无法正确定位。

因此这个 PR 现在同时修复：

- 初始无效/非递增锚点导致的 marker 塌缩；
- ChatGPT 虚拟滚动阶段的低可信比例布局；
- 稀疏样本、小样本、以及高点数虚拟样本下的时间轴点位异常；
- 滚动到底部时最后一个 marker 无法激活的问题。

## 线上版本 Bug

<table>
  <tr>
    <th>短对话</th>
    <th>长对话</th>
  </tr>
  <tr>
    <td>
      <img
        width="700"
        alt="线上版本 bug"
        src="https://github.com/user-attachments/assets/b490636e-1a31-490a-adf7-7c393417d646"
      />
    </td>
    <td>
      <img
        width="700"
        alt="长对话时"
        src="https://github.com/user-attachments/assets/e40edb1f-3134-4c89-a38e-6b1b33ce2ba9"
      />
    </td>
  </tr>
</table>

## 当前 PR 修复后

<table>
  <tr>
    <th>短对话</th>
    <th>长对话</th>
  </tr>
  <tr>
    <td>
      <img
        width="700"
        alt="修复后"
        src="https://github.com/user-attachments/assets/1f8cd10e-b3b9-47a5-8616-ece3861b70ac"
      />
    </td>
    <td>
      <img
        width="700"
        alt="长对话修复"
        src="https://github.com/user-attachments/assets/98b93607-7c35-4007-b36d-f1b61c5d4aa4"
      />
    </td>
  </tr>
</table>

## 原因

ChatGPT 现在的会话页面在首次进入较长对话时，可能处于虚拟滚动的中间状态：

- 上方历史消息尚未完全加载；
- DOM 中只能测到一部分用户消息锚点；
- 这些锚点的真实全局比例并不可信；
- 如果直接按这些 DOM 位置计算比例，会出现 marker 过度挤压、内部时间轴过长，或上下间距严重失真。

另外，在更早的异常情况下，如果锚点测量无效或非递增，旧 fallback 可能继续沿用塌缩的 previous ratios，例如 `[0, 0, 0]`，导致所有 marker 渲染到顶部。

## 修复

这次调整了 ChatGPT marker ratio 的 fallback 和低可信样本处理：

- 当锚点位置无效或非递增时：
  - 如果存在可信 previous ratios，则继续保留；
  - 如果没有可信 previous ratios，则使用可读的均匀占位比例；
  - 如果 previous ratios 已经塌缩，不再继续保留坏形状。

- 当 ChatGPT 虚拟滚动产生严重偏斜的低可信比例时：
  - 不再因为 marker 数量较多就直接信任 DOM 比例；
  - 改用目录式均匀 spacing，避免未加载历史消息对应的点全部挤在顶部；
  - 避免由虚拟阶段的假比例触发过长内部时间轴。

- 当页面已经滚动到底部时：
  - 优先激活最后一个 marker；
  - 避免最后一个 marker 的目标滚动位置超过实际最大 scrollTop 后导致定位不稳定。

正常锚点测量稳定、比例可信时，仍然保留按真实滚动高度比例展示的行为。

## 测试

新增/更新回归测试覆盖：

- 锚点位置无效或非递增，且没有可信 previous ratios；
- previous ratios 已经塌缩成 `[0, 0, 0]`；
- sparse virtualized marker samples 不应触发过长内部时间轴；
- 5 个 marker 的虚拟滚动低可信样本；
- 高 marker 数量下的低可信虚拟滚动样本；
- 页面滚动到底部时应激活最后一个 marker；
- 底部 marker 的目标滚动位置需要 clamp 到最大 scrollTop。

本地验证通过：

```bash
powershell -ExecutionPolicy Bypass -File tests/run-node-tests.ps1
```

## 备注

这个问题和 ChatGPT 网页近期的虚拟滚动行为有关，不是稳定可复现的传统 DOM 布局问题。
我尽量把修复限制在 ChatGPT marker ratio normalization、timeline height calculation 和 active marker selection 相关逻辑内，避免影响其他站点。